### PR TITLE
Add NetworkAnimatorP2P

### DIFF
--- a/Assets/Scripts/NetworkAnimatorP2P.cs
+++ b/Assets/Scripts/NetworkAnimatorP2P.cs
@@ -1,0 +1,16 @@
+using Unity.Netcode.Components;
+
+public class NetworkAnimatorP2P : NetworkAnimator
+{
+    /// <summary>
+    /// Change Owner authoritative mode to allow client to send animations to the host.
+    /// <para>
+    /// Use NetworkAnimatorP2P instead of NetworkAnimator,
+    /// and add the Animator as a parameter in Unity
+    /// </para>
+    /// </summary>
+    protected override bool OnIsServerAuthoritative()
+    {
+        return false;
+    }
+}

--- a/Assets/Scripts/NetworkAnimatorP2P.cs.meta
+++ b/Assets/Scripts/NetworkAnimatorP2P.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 46acb726ddc9bf649a220b06aab9f4b0


### PR DESCRIPTION
# Instructions
- Replace all `Animator` and `NetworkAnimator` by `NetworkAnimatorP2P`

_Due to server authoritive policy over `Netcode for Gameobjects`, clients are not allowed to send/modify what happend on host-side, and so will not synchronise animations of other players than the host._ 